### PR TITLE
feat: migrate to spring framework.

### DIFF
--- a/telework-reservation-api/pom.xml
+++ b/telework-reservation-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.koko</groupId>
@@ -52,6 +52,13 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.5.6</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>6.1.11</version>
         </dependency>
 
     </dependencies>

--- a/telework-reservation-api/src/main/java/com/koko/controllers/EmployeeController.java
+++ b/telework-reservation-api/src/main/java/com/koko/controllers/EmployeeController.java
@@ -14,18 +14,22 @@ import com.koko.dtos.ErrorResponse;
 import com.koko.services.EmployeeService;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.HttpRequestHandler;
 
-@WebServlet("/employees")
-public class EmployeeController extends HttpServlet {
-    Logger logger = LoggerFactory.getLogger(EmployeeController.class);
+public class EmployeeController implements HttpRequestHandler {
+
+    private EmployeeService employeeService;
+
+    public void setEmployeeService(EmployeeService employeeService) {
+        this.employeeService = employeeService;
+    }
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+    public void handleRequest(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
+        Logger logger = LoggerFactory.getLogger(EmployeeController.class);
         logger.info("Received request for /employees endpoint.");
 
         String email = request.getParameter("email");
@@ -48,7 +52,7 @@ public class EmployeeController extends HttpServlet {
         }
 
         try {
-            EmployeeDto employeeDto = EmployeeService.verifyCredentials(email, password);
+            EmployeeDto employeeDto = employeeService.verifyCredentials(email, password);
 
             if (Objects.nonNull(employeeDto)) {
                 String json = mapper.writeValueAsString(employeeDto);

--- a/telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
+++ b/telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
@@ -12,10 +12,11 @@ import com.koko.dtos.EmployeeDto;
 import com.koko.utils.DBUtil;
 
 public class EmployeeService {
-    private static final Logger logger = LoggerFactory.getLogger(EmployeeService.class);
 
-    public static EmployeeDto verifyCredentials(String email, String password)
+    public EmployeeDto verifyCredentials(String email, String password)
             throws ClassNotFoundException, SQLException {
+        Logger logger = LoggerFactory.getLogger(EmployeeService.class);
+
         logger.info("Verifying credentials for email: {}", email);
         String sql = "SELECT employee_id,employee_name,email,role FROM employees WHERE email = ? AND password = ?;";
 
@@ -34,7 +35,7 @@ public class EmployeeService {
 
                 logger.info("Successfully verified credentials for email: {}", email);
                 return employeeDto;
-                
+
             } else {
                 logger.warn("Failed to verify credentials: Invalid email or password for email: {}", email);
                 return null;

--- a/telework-reservation-api/src/main/webapp/WEB-INF/application-context.xml
+++ b/telework-reservation-api/src/main/webapp/WEB-INF/application-context.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- Example Bean definitions -->
+    <bean id="employeeService" class="com.koko.services.EmployeeService" />
+</beans>

--- a/telework-reservation-api/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/telework-reservation-api/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="employeeController" class="com.koko.controllers.EmployeeController">
+        <property name="employeeService" ref="employeeService" />
+    </bean>
+
+    <bean name="handlerAdapter"
+        class="org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter" />
+
+    <bean id="handlerMapping"
+        class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">
+        <property name="mappings">
+            <props>
+                <prop key="/employees">employeeController</prop>
+            </props>
+        </property>
+    </bean>
+
+</beans>

--- a/telework-reservation-api/src/main/webapp/WEB-INF/web.xml
+++ b/telework-reservation-api/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://jakarta.ee/xml/ns/jakartaee" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd" version="6.0">
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+  version="6.0">
   <display-name>telework-reservation-api</display-name>
+
+  <!-- DispatcherServlet definition -->
+  <servlet>
+    <servlet-name>dispatcher</servlet-name>
+    <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>dispatcher</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <!-- Spring ContextLoaderListener -->
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
+
+  <context-param>
+    <param-name>contextConfigLocation</param-name>
+    <param-value>/WEB-INF/application-context.xml</param-value>
+  </context-param>
 </web-app>


### PR DESCRIPTION
## Description

- `pom.xml`にSpring Web MVC依存関係を追加
- `EmployeeController`を`HttpRequestHandler`インターフェースを実装するよう変更
- `EmployeeService`の`verifyCredentials`メソッドをインスタンスメソッドに変更
- `application-context.xml`を新規作成し、`employeeService` Beanを定義
- `dispatcher-servlet.xml`を新規作成し、コントローラーとマッピングを定義
- `web.xml`に`DispatcherServlet`と`ContextLoaderListener`を設定

## Changes

- M       telework-reservation-api/pom.xml
- M       telework-reservation-api/src/main/java/com/koko/controllers/EmployeeController.java
- M       telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
- A       telework-reservation-api/src/main/webapp/WEB-INF/application-context.xml
- A       telework-reservation-api/src/main/webapp/WEB-INF/dispatcher-servlet.xml
- M       telework-reservation-api/src/main/webapp/WEB-INF/web.xml

## Reference

- [URLのパスをDIコンテナに記述するサンプル](https://sites.google.com/site/soracane/springnitsuite/spring-mvc/83-can-kao-urlnopasuno-she-dingwo#h.p_ID_72)