### PR TITLE
feat: Spring Frameworkに移行

### DIFF
--- a/docs/spring-framework.md
+++ b/docs/spring-framework.md
@@ -1,0 +1,13 @@
+# spring-framework
+
+## dependecy
+- spring-core ← Springframeworkを使用する中心的な部分 ← 共通部品
+- spring-context ← DIをするための箱
+- spring-beans ← 箱に詰めるInstance
+- spring-aop ← AOPで使用する
+- spring-webmvc ← WebはWebでもリクエストとレスポンスを上手いことする Controller的なもので使用
+- spring-web ← Front側で主に使用されるWeb関連
+- spring-expression ← 知らない
+
+## What is Servlet?
+

--- a/telework-reservation-api/pom.xml
+++ b/telework-reservation-api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.koko</groupId>
@@ -52,6 +52,13 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.5.6</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>6.1.11</version>
         </dependency>
 
     </dependencies>

--- a/telework-reservation-api/src/main/java/com/koko/controllers/EmployeeController.java
+++ b/telework-reservation-api/src/main/java/com/koko/controllers/EmployeeController.java
@@ -2,30 +2,38 @@ package com.koko.controllers;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+
 import java.sql.SQLException;
+
 import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.web.HttpRequestHandler;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.koko.dtos.EmployeeDto;
 import com.koko.dtos.ErrorResponse;
 import com.koko.services.EmployeeService;
 
 import jakarta.servlet.ServletException;
-import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@WebServlet("/employees")
-public class EmployeeController extends HttpServlet {
-    Logger logger = LoggerFactory.getLogger(EmployeeController.class);
+public class EmployeeController implements HttpRequestHandler {
+
+    private EmployeeService employeeService;
+
+    public void setEmployeeService(EmployeeService employeeService) {
+        this.employeeService = employeeService;
+    }
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+    public void handleRequest(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
+        Logger logger = LoggerFactory.getLogger(EmployeeController.class);
         logger.info("Received request for /employees endpoint.");
 
         String email = request.getParameter("email");
@@ -48,7 +56,7 @@ public class EmployeeController extends HttpServlet {
         }
 
         try {
-            EmployeeDto employeeDto = EmployeeService.verifyCredentials(email, password);
+            EmployeeDto employeeDto = employeeService.verifyCredentials(email, password);
 
             if (Objects.nonNull(employeeDto)) {
                 String json = mapper.writeValueAsString(employeeDto);

--- a/telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
+++ b/telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
@@ -12,15 +12,23 @@ import com.koko.dtos.EmployeeDto;
 import com.koko.utils.DBUtil;
 
 public class EmployeeService {
-    private static final Logger logger = LoggerFactory.getLogger(EmployeeService.class);
 
-    public static EmployeeDto verifyCredentials(String email, String password)
+    private DBUtil dbUtil;
+
+    public void setDbUtil(DBUtil dbUtil){
+        this.dbUtil = dbUtil;
+    }
+
+    public EmployeeDto verifyCredentials(String email, String password)
             throws ClassNotFoundException, SQLException {
+
+        Logger logger = LoggerFactory.getLogger(EmployeeService.class);
+
         logger.info("Verifying credentials for email: {}", email);
         String sql = "SELECT employee_id,employee_name,email,role FROM employees WHERE email = ? AND password = ?;";
 
         try (
-                Connection connection = DBUtil.getConnection();
+                Connection connection = dbUtil.getConnection();
                 PreparedStatement statement = connection.prepareStatement(sql);
                 ResultSet resultSet = executeQueryWithParams(email, password, statement);) {
             logger.debug("Executing query: {}", statement.toString());
@@ -34,7 +42,7 @@ public class EmployeeService {
 
                 logger.info("Successfully verified credentials for email: {}", email);
                 return employeeDto;
-                
+
             } else {
                 logger.warn("Failed to verify credentials: Invalid email or password for email: {}", email);
                 return null;

--- a/telework-reservation-api/src/main/java/com/koko/utils/DBUtil.java
+++ b/telework-reservation-api/src/main/java/com/koko/utils/DBUtil.java
@@ -6,7 +6,7 @@ import java.sql.SQLException;
 
 public class DBUtil {
 
-    public static Connection getConnection() throws SQLException, ClassNotFoundException {
+    public Connection getConnection() throws SQLException, ClassNotFoundException {
         final String DB_URL = "jdbc:postgresql://localhost:5432/teleworkreservations";
         final String DB_USER = "postgres";
         final String DB_PASSWORD = "postgres";

--- a/telework-reservation-api/src/main/webapp/WEB-INF/application-context.xml
+++ b/telework-reservation-api/src/main/webapp/WEB-INF/application-context.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- Example Bean definitions -->
+    <bean id="dbUtil" class="com.koko.utils.DBUtil"/>
+    <bean id="employeeService" class="com.koko.services.EmployeeService" >
+        <property name="dbUtil" ref="dbUtil" />
+    </bean>
+</beans>

--- a/telework-reservation-api/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/telework-reservation-api/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="employeeController" class="com.koko.controllers.EmployeeController">
+        <property name="employeeService" ref="employeeService" />
+    </bean>
+
+    <bean name="handlerAdapter"
+        class="org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter" />
+
+    <bean id="handlerMapping"
+        class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">
+        <property name="mappings">
+            <props>
+                <prop key="/employees">employeeController</prop>
+            </props>
+        </property>
+    </bean>
+
+</beans>

--- a/telework-reservation-api/src/main/webapp/WEB-INF/web.xml
+++ b/telework-reservation-api/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://jakarta.ee/xml/ns/jakartaee" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd" version="6.0">
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+  version="6.0">
   <display-name>telework-reservation-api</display-name>
+
+  <!-- DispatcherServlet definition -->
+  <servlet>
+    <servlet-name>dispatcher</servlet-name>
+    <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>dispatcher</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <!-- Spring ContextLoaderListener -->
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
+
+  <context-param>
+    <param-name>contextConfigLocation</param-name>
+    <param-value>/WEB-INF/application-context.xml</param-value>
+  </context-param>
 </web-app>


### PR DESCRIPTION
## Description

- Spring Framework の依存関係追加
  - `spring-webmvc` 依存関係を `pom.xml` に追加
- コントローラークラスの変更
  - `EmployeeController` クラスを Spring の `HttpRequestHandler` インターフェースを実装するように変更
  - `@WebServlet` アノテーションを削除し、Spring の DI による依存性注入を使用するように変更
- サービスクラスの変更
  - `EmployeeService` クラスで `DBUtil` のインスタンスを DI で注入できるように修正
- Spring のコンフィギュレーションファイルの追加
  - `application-context.xml`: DI の設定ファイルを追加
    - `EmployeeService` と `DBUtil` の Bean 定義を追加
  - `dispatcher-servlet.xml`: `DispatcherServlet` の設定ファイルを追加
    - `EmployeeController` を `SimpleUrlHandlerMapping` でマッピングする設定を追加
    - `HttpRequestHandlerAdapter` を追加
- `web.xml` の修正
  - `DispatcherServlet` の定義とマッピングを追加
  - `ContextLoaderListener` を追加し、Spring の `application-context.xml` を読み込むように設定
- ドキュメントの追加
  - `docs/spring-framework.md` を追加し、Spring Framework の各依存関係の役割について簡単に記載


## Changes

- A       docs/spring-framework.md
- M       telework-reservation-api/pom.xml
- M       telework-reservation-api/src/main/java/com/koko/controllers/EmployeeController.java
- M       telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
- M       telework-reservation-api/src/main/java/com/koko/utils/DBUtil.java
- A       telework-reservation-api/src/main/webapp/WEB-INF/application-context.xml
- A       telework-reservation-api/src/main/webapp/WEB-INF/dispatcher-servlet.xml
- M       telework-reservation-api/src/main/webapp/WEB-INF/web.xml

## Reference

- [URLのパスをDIコンテナに記述するサンプル](https://sites.google.com/site/soracane/springnitsuite/spring-mvc/83-can-kao-urlnopasuno-she-dingwo#h.p_ID_72)