### PR TITLE
feat: clientのSpringフレームワーク移行

### DIFF
--- a/telework-reservation-client/pom.xml
+++ b/telework-reservation-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.koko</groupId>
@@ -38,6 +38,14 @@
             <version>1.18.34</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.springframework/spring-webmvc -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>6.1.11</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/telework-reservation-client/src/main/java/com/koko/controllers/LogoutController.java
+++ b/telework-reservation-client/src/main/java/com/koko/controllers/LogoutController.java
@@ -2,19 +2,18 @@ package com.koko.controllers;
 
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.web.HttpRequestHandler;
+
 import java.io.IOException;
 
-@WebServlet("/call-logout")
-public class LogoutController extends HttpServlet {
-    @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+public class LogoutController implements HttpRequestHandler {
 
+    @Override
+    public void handleRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
         RequestDispatcher dispatcher = request.getRequestDispatcher("/index.jsp");
         dispatcher.forward(request, response);
     }

--- a/telework-reservation-client/src/main/java/com/koko/controllers/RootController.java
+++ b/telework-reservation-client/src/main/java/com/koko/controllers/RootController.java
@@ -1,20 +1,19 @@
 package com.koko.controllers;
 
-import java.io.IOException;
-
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.annotation.WebServlet;
-import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-@WebServlet("/")
-public class RootController extends HttpServlet {
-    @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+import org.springframework.web.HttpRequestHandler;
 
+import java.io.IOException;
+
+public class RootController implements HttpRequestHandler {
+
+    @Override
+    public void handleRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
         RequestDispatcher dispatcher = request.getRequestDispatcher("/index.jsp");
         dispatcher.forward(request, response);
     }

--- a/telework-reservation-client/src/main/webapp/WEB-INF/application-context.xml
+++ b/telework-reservation-client/src/main/webapp/WEB-INF/application-context.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+</beans>

--- a/telework-reservation-client/src/main/webapp/WEB-INF/dispatcher-servlet.xml
+++ b/telework-reservation-client/src/main/webapp/WEB-INF/dispatcher-servlet.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- View Resolver -->
+    <bean id="viewResolver"
+        class="org.springframework.web.servlet.view.InternalResourceViewResolver">
+        <property name="prefix" value="/WEB-INF/view/" />
+        <property name="suffix" value=".jsp" />
+    </bean>
+
+    <!-- Controller Beans -->
+    <bean id="rootController" class="com.koko.controllers.RootController" />
+    <bean id="loginController" class="com.koko.controllers.LoginController" />
+    <bean id="logoutController" class="com.koko.controllers.LogoutController" />
+
+    <!-- HttpRequestHandlerAdapter for handling requests -->
+    <bean name="handlerAdapter"
+        class="org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter" />
+
+    <!-- SimpleUrlHandlerMapping for URL mapping -->
+    <bean id="handlerMapping"
+        class="org.springframework.web.servlet.handler.SimpleUrlHandlerMapping">
+        <property name="mappings">
+            <props>
+                <prop key="/">rootController</prop>
+                <prop key="/call-login">loginController</prop>
+                <prop key="/call-logout">logoutController</prop>
+            </props>
+        </property>
+    </bean>
+
+</beans>

--- a/telework-reservation-client/src/main/webapp/WEB-INF/web.xml
+++ b/telework-reservation-client/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://jakarta.ee/xml/ns/jakartaee" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd" version="6.0">
   <display-name>telework-reservation-client</display-name>
+
+  <!-- DispatcherServlet definition -->
+  <servlet>
+    <servlet-name>dispatcher</servlet-name>
+    <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>dispatcher</servlet-name>
+    <url-pattern>/</url-pattern>
+  </servlet-mapping>
+
+  <!-- Spring ContextLoaderListener -->
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
+
+  <context-param>
+    <param-name>contextConfigLocation</param-name>
+    <param-value>/WEB-INF/application-context.xml</param-value>
+  </context-param>
+  
 </web-app>


### PR DESCRIPTION
## Description

- Spring Framework の導入
  - `pom.xml` に `spring-webmvc` 依存関係を追加
- コントローラーの修正
  - すべてのコントローラー (`LoginController`, `LogoutController`, `RootController`) で、`HttpServlet` から `HttpRequestHandler` インターフェースを実装する形に変更
  - `@WebServlet` アノテーションを削除し、Spring による DI を使用するために `dispatcher-servlet.xml` に設定を移行
- Spring のコンフィギュレーションファイル追加
  - `dispatcher-servlet.xml` を追加し、以下の設定を行った
    - `ViewResolver` の設定: `/WEB-INF/view/` ディレクトリ内の `.jsp` ファイルをビューとして使用するための設定を追加
    - コントローラービーンの定義: `RootController`, `LoginController`, `LogoutController` の Bean を定義
    - `HttpRequestHandlerAdapter` を設定し、リクエストをハンドリングするためのアダプターを追加
    - `SimpleUrlHandlerMapping` を使用して、URL とコントローラーをマッピングする設定を追加
- `web.xml` の修正
  - `DispatcherServlet` の定義を追加し、アプリケーションのリクエストを Spring MVC にルーティングするように設定
  - `ContextLoaderListener` を追加し、`application-context.xml` を読み込むように設定
- `application-context.xml` の追加
  - 現時点では空だが、将来的に DI の設定を追加するための `application-context.xml` を作成

## Changes

- M       telework-reservation-client/pom.xml
- M       telework-reservation-client/src/main/java/com/koko/controllers/LoginController.java
- M       telework-reservation-client/src/main/java/com/koko/controllers/LogoutController.java
- M       telework-reservation-client/src/main/java/com/koko/controllers/RootController.java
- A       telework-reservation-client/src/main/webapp/WEB-INF/application-context.xml
- A       telework-reservation-client/src/main/webapp/WEB-INF/dispatcher-servlet.xml
- M       telework-reservation-client/src/main/webapp/WEB-INF/web.xml
