### PR TITLE
feat: PostgresをDockerへ移行

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,17 @@
             "database": "teleworkreservations",
             "username": "postgres",
             "password": "postgres"
+        },
+        {
+            "previewLimit": 50,
+            "server": "localhost",
+            "port": 5432,
+            "driver": "PostgreSQL",
+            "name": "docker-postgres",
+            "database": "teleworkreservations",
+            "username": "postgres",
+            "password": "postgres"
         }
-    ]
+    ],
+    "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  postgres:
+    container_name: telework-reservation-postgres
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: teleworkreservations
+    ports:
+      - 5432:5432
+    volumes:
+      - .docker/postgres:/var/lib/postgresql/data/
+    restart: unless-stopped

--- a/docs/setup-in-wsl.md
+++ b/docs/setup-in-wsl.md
@@ -40,7 +40,12 @@
 - `sdk list maven` ← どのmavenのVersionをInstallするか確認
 - `sdk isntall maven 3.9.8`
 - 基本的にDefault
-### postgres
+### docker-postgres
+- currentディレクトリに`docker-compose.yml`があるか確認
+- ` docker -v` : Docker version xx.x.x, build xxxxxxx
+- ` docker-compose -v` : Docker Compose version v2.xx.x-desktop.1
+- ` docker-compose up -d`
+### postgres(in wsl) 
 - `sudo apt update`
 - `sudo apt install postgresql postgresql-contrib`
 - `sudo -i -u postgres` ← postgresユーザーに変更

--- a/sql/generate-data.sql
+++ b/sql/generate-data.sql
@@ -1,17 +1,9 @@
-DELETE FROM reservations;
-
-DELETE FROM rooms;
-
-DELETE FROM employees;
-
-ALTER SEQUENCE rooms_room_id_seq
-RESTART WITH 1;
-
-ALTER SEQUENCE reservations_reservation_id_seq
-RESTART WITH 1;
+DELETE FROM office_reservation.employees;
+DELETE FROM office_reservation.rooms;
+DELETE FROM office_reservation.reservations;
 
 INSERT INTO
-    employees (employee_id, employee_name, email, password, role)
+    office_reservation.employees (employee_id, employee_name, email, password, role)
 VALUES
     (
         'E0001',
@@ -154,65 +146,65 @@ VALUES
         'NOT_ADMIN'
     );
 
-INSERT INTO
-    rooms (room_name)
+INSERT INTO 
+    office_reservation.rooms (room_id, room_name)
 VALUES
-    ('101'),
-    ('102'),
-    ('103'),
-    ('104'),
-    ('105'),
-    ('106'),
-    ('107'),
-    ('108'),
-    ('109'),
-    ('110'),
-    ('111'),
-    ('112'),
-    ('113'),
-    ('114'),
-    ('115'),
-    ('116'),
-    ('117'),
-    ('118'),
-    ('119'),
-    ('120');
+    ('R001', '101'),
+    ('R002', '102'),
+    ('R003', '103'),
+    ('R004', '104'),
+    ('R005', '105'),
+    ('R006', '106'),
+    ('R007', '107'),
+    ('R008', '108'),
+    ('R009', '109'),
+    ('R010', '110'),
+    ('R011', '111'),
+    ('R012', '112'),
+    ('R013', '113'),
+    ('R014', '114'),
+    ('R015', '115'),
+    ('R016', '116'),
+    ('R017', '117'),
+    ('R018', '118'),
+    ('R019', '119'),
+    ('R020', '120');
 
-INSERT INTO
-    reservations (employee_id, room_id, reservation_date, status)
+INSERT INTO 
+    office_reservation.reservations (reservation_id, employee_id, room_id, reservation_date, status)
 VALUES
-    ('E0001', 1, '2024-08-01', 'RESERVED'),
-    ('E0002', 2, '2024-08-01', 'RESERVED'),
-    ('E0003', 3, '2024-08-01', 'RESERVED'),
-    ('E0004', 4, '2024-08-01', 'RESERVED'),
-    ('E0002', 2, '2024-08-02', 'PENDING'),
-    ('E0003', 3, '2024-08-02', 'PENDING'),
-    ('E0002', 4, '2024-08-02', 'PENDING'),
-    ('E0003', 3, '2024-08-03', 'RESERVED'),
-    ('E0004', 4, '2024-08-04', 'PENDING'),
-    ('E0005', 5, '2024-08-05', 'RESERVED'),
-    ('E0006', 6, '2024-08-06', 'PENDING'),
-    ('E0007', 7, '2024-08-07', 'RESERVED'),
-    ('E0008', 8, '2024-08-08', 'PENDING'),
-    ('E0009', 9, '2024-08-09', 'RESERVED'),
-    ('E0010', 10, '2024-08-10', 'PENDING'),
-    ('E0011', 11, '2024-08-11', 'RESERVED'),
-    ('E0012', 12, '2024-08-12', 'PENDING'),
-    ('E0013', 13, '2024-08-13', 'RESERVED'),
-    ('E0014', 14, '2024-08-14', 'PENDING'),
-    ('E0015', 15, '2024-08-15', 'RESERVED'),
-    ('E0016', 16, '2024-08-16', 'PENDING'),
-    ('E0017', 17, '2024-08-17', 'RESERVED'),
-    ('E0018', 18, '2024-08-18', 'PENDING'),
-    ('E0019', 19, '2024-08-19', 'RESERVED'),
-    ('E0020', 20, '2024-08-20', 'PENDING'),
-    ('E0001', 1, '2024-09-15', 'RESERVED'),
-    ('E0002', 2, '2024-09-15', 'RESERVED'),
-    ('E0003', 3, '2024-09-15', 'RESERVED'),
-    ('E0004', 4, '2024-09-15', 'RESERVED'),
-    ('E0002', 2, '2024-09-17', 'PENDING'),
-    ('E0003', 3, '2024-09-17', 'PENDING'),
-    ('E0002', 4, '2024-09-17', 'PENDING'),
-    ('E0003', 3, '2024-10-03', 'RESERVED'),
-    ('E0004', 4, '2024-10-04', 'PENDING'),
-    ('E0005', 5, '2024-11-05', 'RESERVED');
+    ('RE001', 'E0001', 'R001', '2024-10-01', 'RESERVED'),
+    ('RE002', 'E0002', 'R002', '2024-10-01', 'RESERVED'),
+    ('RE003', 'E0003', 'R003', '2024-10-01', 'RESERVED'),
+    ('RE004', 'E0004', 'R004', '2024-10-01', 'RESERVED'),
+    ('RE005', 'E0002', 'R002', '2024-10-02', 'PENDING'),
+    ('RE006', 'E0003', 'R003', '2024-10-02', 'PENDING'),
+    ('RE007', 'E0002', 'R004', '2024-10-02', 'PENDING'),
+    ('RE008', 'E0003', 'R003', '2024-10-03', 'RESERVED'),
+    ('RE009', 'E0004', 'R004', '2024-10-04', 'PENDING'),
+    ('RE010', 'E0005', 'R005', '2024-10-05', 'RESERVED'),
+    ('RE011', 'E0006', 'R006', '2024-10-06', 'PENDING'),
+    ('RE012', 'E0007', 'R007', '2024-10-07', 'RESERVED'),
+    ('RE013', 'E0008', 'R008', '2024-10-08', 'PENDING'),
+    ('RE014', 'E0009', 'R009', '2024-10-09', 'RESERVED'),
+    ('RE015', 'E0010', 'R010', '2024-10-10', 'PENDING'),
+    ('RE016', 'E0011', 'R011', '2024-10-11', 'RESERVED'),
+    ('RE017', 'E0012', 'R012', '2024-10-12', 'PENDING'),
+    ('RE018', 'E0013', 'R013', '2024-10-13', 'RESERVED'),
+    ('RE019', 'E0014', 'R014', '2024-10-14', 'PENDING'),
+    ('RE020', 'E0015', 'R015', '2024-10-15', 'RESERVED'),
+    ('RE021', 'E0016', 'R016', '2024-10-16', 'PENDING'),
+    ('RE022', 'E0017', 'R017', '2024-10-17', 'RESERVED'),
+    ('RE023', 'E0018', 'R018', '2024-10-18', 'PENDING'),
+    ('RE024', 'E0019', 'R019', '2024-10-19', 'RESERVED'),
+    ('RE025', 'E0020', 'R020', '2024-10-20', 'PENDING'),
+    ('RE026', 'E0001', 'R001', '2024-11-15', 'RESERVED'),
+    ('RE027', 'E0002', 'R002', '2024-11-15', 'RESERVED'),
+    ('RE028', 'E0003', 'R003', '2024-11-15', 'RESERVED'),
+    ('RE029', 'E0004', 'R004', '2024-11-15', 'RESERVED'),
+    ('RE030', 'E0002', 'R002', '2024-11-17', 'PENDING'),
+    ('RE031', 'E0003', 'R003', '2024-11-17', 'PENDING'),
+    ('RE032', 'E0002', 'R004', '2024-11-17', 'PENDING'),
+    ('RE033', 'E0003', 'R003', '2024-12-03', 'RESERVED'),
+    ('RE034', 'E0004', 'R004', '2024-12-04', 'PENDING'),
+    ('RE035', 'E0005', 'R005', '2024-12-05', 'RESERVED');

--- a/sql/generate-table.sql
+++ b/sql/generate-table.sql
@@ -1,37 +1,62 @@
-DROP TABLE IF EXISTS reservations;
+-- スキーマの削除
+DROP SCHEMA IF EXISTS office_reservation CASCADE;
 
-DROP TABLE IF EXISTS employees;
+-- スキーマの作成
+CREATE SCHEMA office_reservation;
 
-DROP TABLE IF EXISTS rooms;
+-- 従業員テーブルの作成 (スキーマ: office_reservation)
+CREATE TABLE office_reservation.employees (
+    employee_id TEXT PRIMARY KEY,  -- 従業員ID: テキスト形式で一意のID
+    employee_name TEXT NOT NULL,            -- 従業員名: テキスト形式で必須
+    email TEXT NOT NULL UNIQUE,             -- メールアドレス: 一意で必須
+    password TEXT NOT NULL,                 -- パスワード: テキスト形式で必須
+    role TEXT NOT NULL CHECK (role IN ('ADMIN', 'NOT_ADMIN')),  -- 役割: 'ADMIN' または 'NOT_ADMIN' のみ許可
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- 作成日時: デフォルトで現在のタイムスタンプ
+    updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP   -- 更新日時: デフォルトで現在のタイムスタンプ
+);
 
-CREATE TABLE
-    employees (
-        employee_id TEXT NOT NULL PRIMARY KEY,
-        employee_name TEXT NOT NULL,
-        email TEXT NOT NULL UNIQUE,
-        password TEXT NOT NULL,
-        role TEXT NOT NULL CHECK (role IN ('ADMIN', 'NOT_ADMIN')),
-        created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
-    );
+-- コメントの追加
+COMMENT ON TABLE office_reservation.employees IS '従業員情報を格納するテーブル';
+COMMENT ON COLUMN office_reservation.employees.employee_id IS '従業員ID: 一意のID';
+COMMENT ON COLUMN office_reservation.employees.employee_name IS '従業員名';
+COMMENT ON COLUMN office_reservation.employees.email IS 'メールアドレス: 一意で必須';
+COMMENT ON COLUMN office_reservation.employees.password IS 'パスワード';
+COMMENT ON COLUMN office_reservation.employees.role IS '役割: 管理者(ADMIN) または一般従業員(NOT_ADMIN)';
+COMMENT ON COLUMN office_reservation.employees.created_at IS '作成日時';
+COMMENT ON COLUMN office_reservation.employees.updated_at IS '更新日時';
 
-CREATE TABLE
-    rooms (
-        room_id SERIAL PRIMARY KEY,
-        room_name TEXT NOT NULL,
-        created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
-    );
+-- 部屋テーブルの作成 (スキーマ: office_reservation)
+CREATE TABLE office_reservation.rooms (
+    room_id TEXT PRIMARY KEY,  -- 部屋ID: テキスト形式で一意ID
+    room_name TEXT NOT NULL,     -- 部屋名: テキスト形式で必須
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- 作成日時: デフォルトで現在のタイムスタンプ
+    updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP   -- 更新日時: デフォルトで現在のタイムスタンプ
+);
 
-CREATE TABLE
-    reservations (
-        reservation_id SERIAL PRIMARY KEY,
-        employee_id TEXT NOT NULL,
-        room_id INTEGER NOT NULL,
-        reservation_date DATE NOT NULL,
-        status TEXT NOT NULL CHECK (status IN ('RESERVED', 'PENDING')),
-        created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (employee_id) REFERENCES employees (employee_id),
-        FOREIGN KEY (room_id) REFERENCES rooms (room_id)
-    );
+-- コメントの追加
+COMMENT ON TABLE office_reservation.rooms IS '予約可能な部屋情報を格納するテーブル';
+COMMENT ON COLUMN office_reservation.rooms.room_id IS '部屋ID: 一意のID';
+COMMENT ON COLUMN office_reservation.rooms.room_name IS '部屋名';
+COMMENT ON COLUMN office_reservation.rooms.created_at IS '作成日時';
+COMMENT ON COLUMN office_reservation.rooms.updated_at IS '更新日時';
+
+-- 予約テーブルの作成 (スキーマ: office_reservation)
+CREATE TABLE office_reservation.reservations (
+    reservation_id TEXT PRIMARY KEY,  -- 予約ID: テキスト形式で一意ID
+    employee_id TEXT NOT NULL,          -- 従業員ID
+    room_id TEXT NOT NULL,           -- 部屋ID
+    reservation_date DATE NOT NULL,     -- 予約日: 日付形式で必須
+    status TEXT NOT NULL CHECK (status IN ('RESERVED', 'PENDING')),  -- 予約ステータス: 'RESERVED' または 'PENDING' のみ許可
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,  -- 作成日時: デフォルトで現在のタイムスタンプ
+    updated_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP  -- 更新日時: デフォルトで現在のタイムスタンプ
+);
+
+-- コメントの追加
+COMMENT ON TABLE office_reservation.reservations IS '部屋予約情報を格納するテーブル';
+COMMENT ON COLUMN office_reservation.reservations.reservation_id IS '予約ID: 一意のID';
+COMMENT ON COLUMN office_reservation.reservations.employee_id IS '従業員ID';
+COMMENT ON COLUMN office_reservation.reservations.room_id IS '部屋ID';
+COMMENT ON COLUMN office_reservation.reservations.reservation_date IS '予約日';
+COMMENT ON COLUMN office_reservation.reservations.status IS '予約ステータス: 予約済み(RESERVED) または 保留中(PENDING)';
+COMMENT ON COLUMN office_reservation.reservations.created_at IS '作成日時';
+COMMENT ON COLUMN office_reservation.reservations.updated_at IS '更新日時';

--- a/telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
+++ b/telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
@@ -25,7 +25,7 @@ public class EmployeeService {
         Logger logger = LoggerFactory.getLogger(EmployeeService.class);
 
         logger.info("Verifying credentials for email: {}", email);
-        String sql = "SELECT employee_id,employee_name,email,role FROM employees WHERE email = ? AND password = ?;";
+        String sql = "SELECT employee_id,employee_name,email,role FROM office_reservation.employees WHERE email = ? AND password = ?;";
 
         try (
                 Connection connection = dbUtil.getConnection();


### PR DESCRIPTION
## Description

- `docker-compose.yml` の追加
  - 新規に `docker-compose.yml` を追加し、PostgreSQLコンテナの設定
    - `POSTGRES_USER`、`POSTGRES_PASSWORD`、`POSTGRES_DB` の環境変数を設定
    - ポート `5432` を公開

- `settings.json` の更新
  - VSCodeの設定ファイルにPostgreSQLの設定を追加
    - `docker-postgres` として新たにデータベース接続設定を追加

- SQLスクリプトの修正
  - `generate-data.sql` の修正:
    - スキーマ名 `office_reservation` を使用するように変更
    - テーブル名にスキーマ名を追加し、データを挿入する際に一意なIDを持つように調整

  - `generate-table.sql` の修正:
    - スキーマ `office_reservation` を削除し再作成する処理を追加
    - 各テーブルの作成時にスキーマ名を付与
    - テーブルの列にコメントを追加し、各列の役割を明示

- `EmployeeService.java` の修正
  - SQLクエリを修正し、テーブル名にスキーマ名 `office_reservation` を追加

## Changes

- M       .vscode/settings.json
- A       docker-compose.yml
- M       docs/setup-in-wsl.md
- M       sql/generate-data.sql
- M       sql/generate-table.sql
- M       telework-reservation-api/src/main/java/com/koko/services/EmployeeService.java
